### PR TITLE
Rename Symmetric\StaticKey class to SymmetricKeyEncryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,21 @@ to generate a key. You can have multiple keys in each group (here we see two gro
 Then define services for each key group (feel free to commit this):
 ```
 services:
-    emailEncryption: \Spaze\Encryption\Symmetric\StaticKey('email', %encryption.keys%, %encryption.activeKeyIds%)
-    passwordHashEncryption: \Spaze\Encryption\Symmetric\StaticKey('passwordHash', %encryption.keys%, %encryption.activeKeyIds%)
+    emailEncryption: \Spaze\Encryption\SymmetricKeyEncryption('email', %encryption.keys%, %encryption.activeKeyIds%)
+    passwordHashEncryption: \Spaze\Encryption\SymmetricKeyEncryption('passwordHash', %encryption.keys%, %encryption.activeKeyIds%)
 ```
 
 Use the services in this class which needs to encrypt and decrypt email addresses for whatever reason:
 ```php
-use Spaze\Encryption\Symmetric\StaticKey as StaticKeyEncryption;
+use Spaze\Encryption\SymmetricKeyEncryption;
 
 class Something
 {
 
-    /** @var StaticKeyEncryption */
+    /** @var SymmetricKeyEncryption */
     private $emailEncryption;
 
-    public function __construct(StaticKeyEncryption $emailEncryption)
+    public function __construct(SymmetricKeyEncryption $emailEncryption)
     {
         // ...
     }

--- a/src/SymmetricKeyEncryption.php
+++ b/src/SymmetricKeyEncryption.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Spaze\Encryption\Symmetric;
+namespace Spaze\Encryption;
 
 use OutOfBoundsException;
 use OutOfRangeException;
@@ -17,12 +17,7 @@ use ParagonIE\HiddenString\HiddenString;
 use SodiumException;
 use TypeError;
 
-/**
- * StaticKey encryption service.
- *
- * @author Michal Špaček
- */
-class StaticKey
+class SymmetricKeyEncryption
 {
 
 	private const KEY_CIPHERTEXT_SEPARATOR = '$';

--- a/tests/SymmetricKeyEncryptionTest.phpt
+++ b/tests/SymmetricKeyEncryptionTest.phpt
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 
 namespace Spaze\Encryption\Symmetric;
 
+use Spaze\Encryption\SymmetricKeyEncryption;
 use Tester\Assert;
 use Tester\TestCase;
 
 require __DIR__ . '/bootstrap.php';
 
 /** @testCase */
-class StaticKeyTest extends TestCase
+class SymmetricKeyEncryptionTest extends TestCase
 {
 
 	private const KEY_GROUP = 'token';
@@ -27,7 +28,7 @@ class StaticKeyTest extends TestCase
 	/** @var string[] */
 	private array $activeKeyIds;
 
-	private StaticKey $encryption;
+	private SymmetricKeyEncryption $encryption;
 
 
 	protected function setUp(): void
@@ -41,7 +42,7 @@ class StaticKeyTest extends TestCase
 		$this->activeKeyIds = [
 			self::KEY_GROUP => self::ACTIVE_KEY,
 		];
-		$this->encryption = new StaticKey(self::KEY_GROUP, $this->keys, $this->activeKeyIds);
+		$this->encryption = new SymmetricKeyEncryption(self::KEY_GROUP, $this->keys, $this->activeKeyIds);
 	}
 
 
@@ -53,14 +54,14 @@ class StaticKeyTest extends TestCase
 
 	public function testEncryptInactiveKeyDecrypt(): void
 	{
-		$inactiveKeyEncryption = new StaticKey(self::KEY_GROUP, $this->keys, [self::KEY_GROUP => self::INACTIVE_KEY]);
+		$inactiveKeyEncryption = new SymmetricKeyEncryption(self::KEY_GROUP, $this->keys, [self::KEY_GROUP => self::INACTIVE_KEY]);
 		Assert::same(self::PLAINTEXT, $this->encryption->decrypt($inactiveKeyEncryption->encrypt(self::PLAINTEXT)));
 	}
 
 
 	public function testNeedsReEncrypt(): void
 	{
-		$inactiveKeyEncryption = new StaticKey(self::KEY_GROUP, $this->keys, [self::KEY_GROUP => self::INACTIVE_KEY]);
+		$inactiveKeyEncryption = new SymmetricKeyEncryption(self::KEY_GROUP, $this->keys, [self::KEY_GROUP => self::INACTIVE_KEY]);
 		Assert::false($inactiveKeyEncryption->needsReEncrypt($inactiveKeyEncryption->encrypt(self::PLAINTEXT)));
 		Assert::true($this->encryption->needsReEncrypt($inactiveKeyEncryption->encrypt(self::PLAINTEXT)));
 		Assert::true($inactiveKeyEncryption->needsReEncrypt($this->encryption->encrypt(self::PLAINTEXT)));
@@ -68,4 +69,4 @@ class StaticKeyTest extends TestCase
 
 }
 
-(new StaticKeyTest())->run();
+(new SymmetricKeyEncryptionTest())->run();


### PR DESCRIPTION
Makes no sense to have a decrypt method on a key object, which is not even a key object.