### PR TITLE
Hide sensitive keys and plaintext

### DIFF
--- a/src/SymmetricKeyEncryption.php
+++ b/src/SymmetricKeyEncryption.php
@@ -13,6 +13,7 @@ use ParagonIE\Halite\Alerts\InvalidType;
 use ParagonIE\Halite\Symmetric\Crypto;
 use ParagonIE\Halite\Symmetric\EncryptionKey;
 use ParagonIE\HiddenString\HiddenString;
+use SensitiveParameter;
 use SodiumException;
 use Spaze\Encryption\Exceptions\InvalidNumberOfComponentsException;
 use Spaze\Encryption\Exceptions\UnknownEncryptionKeyIdException;
@@ -32,7 +33,7 @@ class SymmetricKeyEncryption
 	 */
 	public function __construct(
 		private string $keyGroup,
-		private array $keys,
+		#[SensitiveParameter] private array $keys,
 		private array $activeKeyIds,
 	) {
 	}
@@ -48,7 +49,7 @@ class SymmetricKeyEncryption
 	 * @throws TypeError
 	 * @throws UnknownEncryptionKeyIdException
 	 */
-	public function encrypt(string $data): string
+	public function encrypt(#[SensitiveParameter] string $data): string
 	{
 		$keyId = $this->getActiveKeyId();
 		$key = $this->getKey($keyId);

--- a/src/SymmetricKeyEncryption.php
+++ b/src/SymmetricKeyEncryption.php
@@ -26,6 +26,9 @@ class SymmetricKeyEncryption
 
 	private const KEY_CIPHERTEXT_SEPARATOR = '$';
 
+	/** @var array<string, array<string, HiddenString>> */
+	private array $keys = [];
+
 
 	/**
 	 * @param array<string, array<string, string>> $keys key group => key id => key
@@ -33,9 +36,14 @@ class SymmetricKeyEncryption
 	 */
 	public function __construct(
 		private string $keyGroup,
-		#[SensitiveParameter] private array $keys,
+		#[SensitiveParameter] array $keys,
 		private array $activeKeyIds,
 	) {
+		foreach ($keys as $name => $group) {
+			foreach ($group as $id => $key) {
+				$this->keys[$name][$id] = new HiddenString(Hex::decode($key));
+			}
+		}
 	}
 
 
@@ -98,7 +106,7 @@ class SymmetricKeyEncryption
 	private function getKey(string $keyId): EncryptionKey
 	{
 		if (isset($this->keys[$this->keyGroup][$keyId])) {
-			return new EncryptionKey(new HiddenString(Hex::decode($this->keys[$this->keyGroup][$keyId])));
+			return new EncryptionKey($this->keys[$this->keyGroup][$keyId]);
 		} else {
 			throw new UnknownEncryptionKeyIdException($keyId);
 		}

--- a/tests/SymmetricKeyEncryptionTest.phpt
+++ b/tests/SymmetricKeyEncryptionTest.phpt
@@ -34,7 +34,7 @@ class SymmetricKeyEncryptionTest extends TestCase
 	protected function setUp(): void
 	{
 		$this->keys = [
-			'token' => [
+			self::KEY_GROUP => [
 				self::INACTIVE_KEY => bin2hex(random_bytes(32)),
 				self::ACTIVE_KEY => bin2hex(random_bytes(32)),
 			],
@@ -112,6 +112,14 @@ class SymmetricKeyEncryptionTest extends TestCase
 		);
 		Assert::notContains(self::PLAINTEXT, $e->getTraceAsString());
 		Assert::contains('SensitiveParameterValue', $e->getTraceAsString());
+	}
+
+
+	public function testHiddenStringKeys(): void
+	{
+		$object = print_r(new SymmetricKeyEncryption(self::KEY_GROUP, $this->keys, [self::KEY_GROUP => self::ACTIVE_KEY]), true);
+		Assert::notContains($this->keys[self::KEY_GROUP][self::ACTIVE_KEY], $object);
+		Assert::notContains($this->keys[self::KEY_GROUP][self::INACTIVE_KEY], $object);
 	}
 
 }

--- a/tests/SymmetricKeyEncryptionTest.phpt
+++ b/tests/SymmetricKeyEncryptionTest.phpt
@@ -101,6 +101,19 @@ class SymmetricKeyEncryptionTest extends TestCase
 		];
 	}
 
+
+	public function testEncryptSensitiveParameter(): void
+	{
+		$e = Assert::exception(
+			function () {
+				(new SymmetricKeyEncryption(self::KEY_GROUP, $this->keys, [self::KEY_GROUP => 'foo']))->encrypt(self::PLAINTEXT);
+			},
+			UnknownEncryptionKeyIdException::class,
+		);
+		Assert::notContains(self::PLAINTEXT, $e->getTraceAsString());
+		Assert::contains('SensitiveParameterValue', $e->getTraceAsString());
+	}
+
 }
 
 (new SymmetricKeyEncryptionTest())->run();


### PR DESCRIPTION
Parameters are hidden with `SensitiveParameter` which is available starting with PHP 8.2 (see #13), keys property with `HiddenString`.