### PR TITLE
Add a prefix to encryption keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,39 @@ Various encryption helpers, uses [`paragonie/halite`](https://github.com/paragon
 
 ## Usage in Nette framework
 
+Although it can be used anywhere, this library doesn't depend on anything from the Nette Framework.
+
 ### Define encryption keys
 
-Add this to your `config.local.neon` parameters section (DO NOT COMMIT THIS TO REPOSITORY):
+Add this (or similar) to your `config.local.neon` parameters section (DO NOT COMMIT THIS TO REPOSITORY):
 ```
 encryption:
     keys:
         passwordHash:
-            prod1: "abadcafec15c..." # [0-9A-F]{64}
+            prod1: "phek_abadcafec15c..." # prefix _ [0-9A-F]{64}
         email:
-            prod1: "cafebabe25da..." # [0-9A-F]{64}
+            prod1: "eek_cafebabe25da..." # prefix _ [0-9A-F]{64}
     activeKeyIds:
         passwordHash: prod1
         email: prod1
+    prefixes:
+        passwordHash: phek # password hash encryption key
+        email: eek # email encryption key
 ```
 YOU HAVE TO GENERATE YOUR OWN KEYS. You can use for example
 ```php
 bin2hex(random_bytes(32))
 ```
-to generate a key. You can have multiple keys in each group (here we see two groups: `password` and `email`), meaning you will be able to decrypt data encrypted with these keys. Data will always be encrypted with what's defined in `activeKeyIds` section.
+to generate a key, then add the prefix. You can have multiple keys in each group (here we see two groups: `password` and `email`), meaning you will be able to decrypt data encrypted with these keys. Data will always be encrypted with what's defined in `activeKeyIds` section.
+
+The configuration is an example one, you don't need to use groups, or even the config key names (like `activeKeyIds`), the only place where these will be used is when you define the service, or services. 
 
 ### Services
 Then define services for each key group (feel free to commit this):
 ```
 services:
-    emailEncryption: \Spaze\Encryption\SymmetricKeyEncryption('email', %encryption.keys%, %encryption.activeKeyIds%)
-    passwordHashEncryption: \Spaze\Encryption\SymmetricKeyEncryption('passwordHash', %encryption.keys%, %encryption.activeKeyIds%)
+    emailEncryption: \Spaze\Encryption\SymmetricKeyEncryption(%encryption.keys.passwordHash%, %encryption.activeKeyIds.passwordHash%, %encryption.prefixes.passwordHash%)
+    passwordHashEncryption: \Spaze\Encryption\SymmetricKeyEncryption(%encryption.keys.email%, %encryption.activeKeyIds.email%, %encryption.prefixes.email%)
 ```
 
 Use the services in this class which needs to encrypt and decrypt email addresses for whatever reason:

--- a/src/Exceptions/InvalidKeyPrefixException.php
+++ b/src/Exceptions/InvalidKeyPrefixException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\Encryption\Exceptions;
+
+use Exception;
+use Throwable;
+
+class InvalidKeyPrefixException extends Exception
+{
+
+	public function __construct(string $prefix, ?string $keyStartsWith, ?Throwable $previous = null)
+	{
+		parent::__construct($keyStartsWith === null ? 'Key has no prefix' : "Key prefix is '{$keyStartsWith}' but it should be '{$prefix}'", previous: $previous);
+	}
+
+}


### PR DESCRIPTION
You can choose whatever but usually it's something like `msceek` for "michalspacek.cz email encryption key" and then the key needs to be `msceek_DEADBEEF1337...`.

This is to help find the key if commited to a repo with tools like [Gitleaks](https://gitleaks.io/).