### PR TITLE
Exclude PHPCS constant type hint checks

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,7 +5,9 @@
 	<arg name="colors"/>
 	<arg value="s"/>
 	<arg value="p"/>
-	<rule ref="vendor/spaze/coding-standard/src/ruleset.xml"/>
+	<rule ref="vendor/spaze/coding-standard/src/ruleset.xml">
+		<exclude name="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint" />
+	</rule>
 	<rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>


### PR DESCRIPTION
This is required by newer spaze/coding-standard but it's a PHP 8.3 feature and I think I still want to support PHP 8.2.