### PR TITLE
Run tests on PHP 8.5 too

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,6 +13,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
     steps:
     - uses: actions/checkout@v5

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"phpstan/phpstan": "^1.10",
-		"nette/tester": "^2.5"
+		"nette/tester": "^2.5.7"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
Also require Tester with PHP 8.5 support (2.5.7), otherwise `--prefer-lowest` tests would fail on 8.5. Luckily (‽), ~~tests are not yet run with `--prefer-lowest` though~~ (now they are: #25).